### PR TITLE
[Claude] Fix GitHub CI build and test steps

### DIFF
--- a/.github/setup/action.yaml
+++ b/.github/setup/action.yaml
@@ -3,11 +3,15 @@ description: Sets up all the dependencies necessary to build the project.
 runs:
   using: 'composite'
   steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
       with:
         version: 10
-        cache: true
 
     - name: Install JS dependencies
       shell: bash
@@ -22,5 +26,6 @@ runs:
         toolchain: stable
 
     - name: Install wasm-pack
-      shell: bash
-      run: cargo install wasm-pack
+      uses: jetli/wasm-pack-action@v0.4.0
+      with:
+        version: 'latest'

--- a/src/external_controller/externalController.test.ts
+++ b/src/external_controller/externalController.test.ts
@@ -3,7 +3,6 @@ import {
   ControllerMappingSchema,
   ControllerMapping_ActionSchema,
 } from '@dmx-controller/proto/controller_pb';
-import { ControllerChannel } from '../contexts/ControllerContext';
 import { randomUint64 } from '../util/numberUtils';
 import { createNewProject } from '../util/projectUtils';
 import { getActiveScene } from '../util/sceneUtils';
@@ -25,22 +24,26 @@ describe('externalController', () => {
       const project = createNewProject();
       let beatSample: number | null = null;
       const addBeatSample = (t: number) => (beatSample = t);
-      let output: { channel: ControllerChannel; value: number } | null = null;
-      performAction(
+      let firstBeat: number | null = null;
+      const setFirstBeat = (t: number) => (firstBeat = t);
+      let beat: number | null = null;
+      const setBeat = (durationMs: number) => (beat = durationMs);
+
+      const result = performAction(
         project,
         'unknown',
         CHANNEL_NAME,
         1,
         null,
         addBeatSample,
-        () => {},
-        (c, v) => {
-          output = { channel: c, value: v };
-        },
+        setFirstBeat,
+        setBeat,
       );
 
+      expect(result).toBe(false);
       expect(beatSample).toBeNull();
-      expect(output).toEqual({ channel: CHANNEL_NAME, value: 1 });
+      expect(firstBeat).toBeNull();
+      expect(beat).toBeNull();
     });
 
     it('should add beat match', () => {
@@ -61,22 +64,26 @@ describe('externalController', () => {
       });
       let beatSample: number | null = null;
       const addBeatSample = (t: number) => (beatSample = t);
-      let output: { channel: ControllerChannel; value: number } | null = null;
-      performAction(
+      let firstBeat: number | null = null;
+      const setFirstBeat = (t: number) => (firstBeat = t);
+      let beat: number | null = null;
+      const setBeat = (durationMs: number) => (beat = durationMs);
+
+      const result = performAction(
         project,
         CONTROLLER_NAME,
         CHANNEL_NAME,
         1,
         null,
         addBeatSample,
-        () => {},
-        (c, v) => {
-          output = { channel: c, value: v };
-        },
+        setFirstBeat,
+        setBeat,
       );
 
+      expect(result).toBe(false);
       expect(beatSample).toEqual(946684800000);
-      expect(output).toBeNull();
+      expect(firstBeat).toBeNull();
+      expect(beat).toBeNull();
     });
 
     it('should set color palette', () => {

--- a/src/wasm-engine/Cargo.toml
+++ b/src/wasm-engine/Cargo.toml
@@ -15,3 +15,6 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 [profile.release]
 opt-level = "z"
 lto = true
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false


### PR DESCRIPTION
This commit fixes the GitHub CI pipeline to ensure build and test steps pass reliably:

1. Optimize wasm-pack installation:
   - Replace slow 'cargo install wasm-pack' with jetli/wasm-pack-action
   - This uses pre-built binaries instead of compiling from source

2. Add explicit Node.js setup:
   - Configure Node.js 20 explicitly for consistent environment

3. Disable wasm-opt in release builds:
   - Add wasm-opt = false to avoid binaryen download dependency
   - Rust compiler optimizations (opt-level = "z", lto = true) still applied

4. Fix failing tests:
   - Update externalController.test.ts to match current API signature
   - Remove unused ControllerChannel import
   - Fix callback signatures for performAction tests

All tests now pass and build completes successfully.