### PR TITLE
[Claude] Set up GitHub workflow for Debian releases

### DIFF
--- a/.github/setup/action.yaml
+++ b/.github/setup/action.yaml
@@ -29,3 +29,15 @@ runs:
       uses: jetli/wasm-pack-action@v0.4.0
       with:
         version: 'latest'
+
+    - name: Install Tauri system dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libwebkit2gtk-4.1-dev \
+          build-essential \
+          libxdo-dev \
+          libssl-dev \
+          libayatana-appindicator3-dev \
+          librsvg2-dev

--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -1,0 +1,40 @@
+name: Build Debian Package
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-debian:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/setup
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libasound2-dev
+
+      - name: Build Tauri app
+        run: pnpm tauri build --bundles deb
+
+      - name: Upload Debian package
+        uses: actions/upload-artifact@v4
+        with:
+          name: debian-package
+          path: src-tauri/target/release/bundle/deb/*.deb
+          if-no-files-found: error

--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -20,14 +20,10 @@ jobs:
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
             build-essential \
-            curl \
-            wget \
-            file \
             libxdo-dev \
             libssl-dev \
             libayatana-appindicator3-dev \
-            librsvg2-dev \
-            libasound2-dev
+            librsvg2-dev
 
       - name: Build Tauri app
         run: pnpm tauri build --bundles deb

--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -14,17 +14,6 @@ jobs:
       - name: Setup
         uses: ./.github/setup
 
-      - name: Install Tauri system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            build-essential \
-            libxdo-dev \
-            libssl-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev
-
       - name: Build Tauri app
         run: pnpm tauri build --bundles deb
 


### PR DESCRIPTION
This workflow builds a Debian x86_64 installer for the Tauri application. The workflow can be triggered manually via workflow_dispatch and installs all necessary system dependencies for Tauri before building the .deb package.