### PR TITLE
[Claude] Add automatic triggering on version changes

### DIFF
--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -1,11 +1,51 @@
 name: Build Debian Package
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src-tauri/tauri.conf.json'
   workflow_dispatch:
 
 jobs:
+  check-version:
+    runs-on: ubuntu-22.04
+    outputs:
+      version-changed: ${{ steps.version_check.outputs.changed }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if version changed
+        id: version_check
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "Manual trigger - skipping version check"
+            echo "changed=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          CURRENT_VERSION=$(grep -oP '(?<="version": ")[^"]*' src-tauri/tauri.conf.json)
+          PREVIOUS_VERSION=$(git show HEAD~1:src-tauri/tauri.conf.json | grep -oP '(?<="version": ")[^"]*')
+
+          echo "Current version: $CURRENT_VERSION"
+          echo "Previous version: $PREVIOUS_VERSION"
+
+          if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
+            echo "Version changed from $PREVIOUS_VERSION to $CURRENT_VERSION"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version unchanged - skipping build"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
   build-debian:
     runs-on: ubuntu-22.04
+    needs: check-version
+    if: needs.check-version.outputs.version-changed == 'true'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
- Trigger workflow on push to main when tauri.conf.json changes
- Add version change detection to only build when version field changes
- Split into two jobs for clean early exit without failure state
- Manual triggers (workflow_dispatch) bypass version check