### PR TITLE
[Claude] Add Windows MSI and macOS DMG build support

### DIFF
--- a/.github/setup/action.yaml
+++ b/.github/setup/action.yaml
@@ -17,9 +17,21 @@ runs:
       shell: bash
       run: pnpm install
 
-    - name: Install protoc
+    - name: Install protoc (Linux)
+      if: runner.os == 'Linux'
       shell: bash
       run: sudo apt install -y protobuf-compiler
+
+    - name: Install protoc (Windows)
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        choco install protoc -y
+
+    - name: Install protoc (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: brew install protobuf
 
     - uses: actions-rs/toolchain@v1
       with:
@@ -30,7 +42,8 @@ runs:
       with:
         version: 'latest'
 
-    - name: Install Tauri system dependencies
+    - name: Install Tauri system dependencies (Linux only)
+      if: runner.os == 'Linux'
       shell: bash
       run: |
         sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,56 +67,53 @@ jobs:
           path: src-tauri/target/release/bundle/deb/*.deb
           if-no-files-found: error
 
-  # TODO: Uncomment when ready to build Windows installers
-  # build-windows:
-  #   runs-on: windows-latest
-  #   needs: check-version
-  #   if: needs.check-version.outputs.version-changed == 'true'
-  #
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #
-  #     - name: Setup
-  #       uses: ./.github/setup
-  #
-  #     - name: Build Tauri app
-  #       run: pnpm tauri build --bundles msi
-  #
-  #     - name: Upload Windows installer
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: windows-installer
-  #         path: src-tauri/target/release/bundle/msi/*.msi
-  #         if-no-files-found: error
+  build-windows:
+    runs-on: windows-latest
+    needs: check-version
+    if: needs.check-version.outputs.version-changed == 'true'
 
-  # TODO: Uncomment when ready to build macOS installers
-  # build-macos:
-  #   runs-on: macos-latest
-  #   needs: check-version
-  #   if: needs.check-version.outputs.version-changed == 'true'
-  #
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #
-  #     - name: Setup
-  #       uses: ./.github/setup
-  #
-  #     - name: Build Tauri app
-  #       run: pnpm tauri build --bundles dmg
-  #
-  #     - name: Upload macOS installer
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: macos-installer
-  #         path: src-tauri/target/release/bundle/dmg/*.dmg
-  #         if-no-files-found: error
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/setup
+
+      - name: Build Tauri app
+        run: pnpm tauri build --bundles msi
+
+      - name: Upload Windows installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer
+          path: src-tauri/target/release/bundle/msi/*.msi
+          if-no-files-found: error
+
+  build-macos:
+    runs-on: macos-latest
+    needs: check-version
+    if: needs.check-version.outputs.version-changed == 'true'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/setup
+
+      - name: Build Tauri app
+        run: pnpm tauri build --bundles dmg
+
+      - name: Upload macOS installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-installer
+          path: src-tauri/target/release/bundle/dmg/*.dmg
+          if-no-files-found: error
 
   publish-release:
     runs-on: ubuntu-22.04
-    needs: [check-version, build-debian]
-    # TODO: Add build-windows and build-macos to needs array when implemented
+    needs: [check-version, build-debian, build-windows, build-macos]
     if: needs.check-version.outputs.version-changed == 'true'
     permissions:
       contents: write
@@ -128,18 +125,17 @@ jobs:
           name: debian-package
           path: artifacts
 
-      # TODO: Add download steps for Windows and macOS artifacts when implemented
-      # - name: Download Windows installer
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: windows-installer
-      #     path: artifacts
-      #
-      # - name: Download macOS installer
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: macos-installer
-      #     path: artifacts
+      - name: Download Windows installer
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-installer
+          path: artifacts
+
+      - name: Download macOS installer
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-installer
+          path: artifacts
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
- Enable Windows and macOS build jobs in release workflow
- Add build-windows and build-macos to publish-release dependencies
- Make setup action cross-platform (Linux, Windows, macOS)
- Install protoc using platform-specific package managers
- Make Tauri dependencies Linux-only (Windows/macOS use native webviews)
- Releases now include .deb (Debian), .msi (Windows), and .dmg (macOS) installers
- All three builds must succeed for release to be published