### PR TITLE
[Claude] Fix deprecated set-output warning in GitHub Actions

### DIFF
--- a/.github/setup/action.yaml
+++ b/.github/setup/action.yaml
@@ -38,9 +38,9 @@ runs:
         toolchain: stable
 
     - name: Install wasm-pack
-      uses: jetli/wasm-pack-action@v0.4.0
+      uses: taiki-e/install-action@v2
       with:
-        version: 'latest'
+        tool: wasm-pack
 
     - name: Install Tauri system dependencies (Linux only)
       if: runner.os == 'Linux'


### PR DESCRIPTION
Replace jetli/wasm-pack-action with taiki-e/install-action for cross-platform wasm-pack installation. This eliminates the deprecated set-output command and works reliably on Linux, macOS, and Windows.