### PR TITLE
Fix TypeScript type-check failures by updating moduleResolution to bundler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "ESNext",
     "lib": ["DOM", "ESNext"],
     "skipLibCheck": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "sourceMap": true,
     "inlineSources": true,
     "strict": true,


### PR DESCRIPTION
TypeScript 5.9 deprecated moduleResolution: node (node10). This caused
TS2688 errors because @types/jest@30.0.0 and vite/client use the package
exports field, which is only respected in node16+/bundler resolution modes.

Switching to moduleResolution: bundler is the recommended setting for
Vite projects and resolves all three CI type-check failures:
- TS5107: moduleResolution=node10 deprecated warning
- TS2688: Cannot find type definition file for 'jest'
- TS2688: Cannot find type definition file for 'vite/client'

https://claude.ai/code/session_01J6oNDFcRZUy2hHtGvxzCc3